### PR TITLE
fix(TextField): デザイン調整 

### DIFF
--- a/src/styles/tailwind.v2.css
+++ b/src/styles/tailwind.v2.css
@@ -120,6 +120,7 @@
   --primary-border-dark-default: #070E2C;
   --primary-border-dark-hover: #474f71;
   --primary-border-dark-disabled: #d4d9ec;
+  --primary-border-medium-active: #474F71;
 
   /*******************************
    * primary icon

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -58,10 +58,10 @@ const styles = {
   `,
   outlined: css`
     & .MuiOutlinedInput-root {
-      ${tw`p-0! text-shade-light-default`}
+      ${tw`p-0! text-shade-light-default bg-shade-white-default antialiased`}
 
       &.Mui-disabled {
-        ${tw`bg-primary-light-default`}
+        ${tw`bg-shade-white-disabled`}
       }
 
       & fieldset {
@@ -69,11 +69,11 @@ const styles = {
       }
 
       &.Mui-disabled .MuiOutlinedInput-notchedOutline {
-        ${tw`border border-shade-medium-default`}
+        ${tw`border border-shade-medium-disabled`}
       }
 
       &.Mui-focused .MuiOutlinedInput-notchedOutline {
-        ${tw`border border-primary-dark-default`}
+        ${tw`border border-primary-medium-active`}
       }
 
       &.Mui-error .MuiOutlinedInput-notchedOutline {
@@ -87,6 +87,11 @@ const styles = {
           ${tw`mr-3 text-r font-sans text-shade-dark-default antialiased`}
         }
       }
+
+      &.Mui-disabled .MuiInputAdornment-root .MuiTypography-root {
+        ${tw`text-shade-dark-disabled`}
+      }
+
       &:hover {
         & fieldset {
           ${tw`border border-primary-dark-default`}
@@ -118,10 +123,6 @@ const styles = {
       ${tw`py-2 px-3 focus:shadow-none text-shade-dark-default`}
     }
 
-    & .MuiFormHelperText-root {
-      > .Mui-error {
-        ${tw`text-negative-medium-default`}
-      }
     & .MuiInputBase-input::placeholder {
       ${tw`text-shade-light-default opacity-100`}
     }
@@ -129,6 +130,9 @@ const styles = {
     & .MuiInputBase-input:disabled::placeholder {
       ${tw`-webkit-text-fill-color[currentColor]` /* to remove -webkit-text-fill-color set by default*/ }
     }
+
+    & .MuiFormHelperText-root.Mui-error {
+      ${tw`m-0 mt-1 text-xs text-negative-medium-default`}
     }
   `,
 }

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -120,7 +120,7 @@ const styles = {
     }
 
     & .MuiInputBase-input {
-      ${tw`py-2 px-3 focus:shadow-none text-shade-dark-default`}
+      ${tw`py-2.5 px-3 h-auto text-r font-sans text-shade-dark-default focus:shadow-none`}
     }
 
     & .MuiInputBase-input::placeholder {

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -80,6 +80,13 @@ const styles = {
         ${tw`border border-negative-medium-default`}
       }
 
+      & .MuiInputAdornment-root {
+        ${tw`m-0`}
+
+        & .MuiTypography-root {
+          ${tw`mr-3 text-r font-sans text-shade-dark-default antialiased`}
+        }
+      }
       &:hover {
         & fieldset {
           ${tw`border border-primary-dark-default`}
@@ -234,6 +241,10 @@ export const TextField: React.ForwardRefExoticComponent<TextFieldProps> =
               css={[
                 styles['outlined'],
                 css`
+                  & .MuiInputBase-input {
+                    ${unitLabel && tw`pr-2 text-right`}
+                  }
+
                   & .MuiInputBase-root {
                     ${inputTwin}
                   }

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -220,7 +220,7 @@ export const TextField: React.ForwardRefExoticComponent<TextFieldProps> =
         return (
           <div css={[tw`flex flex-col`, twin]}>
             {label && (
-              <label css={[tw`mb-2 text-shade-medium-default`, labelTwin]}>
+              <label css={[tw`mb-1 text-s font-bold text-shade-medium-default antialiased`, labelTwin]}>
                 {label}
                 {required && <span tw="text-negative-medium-default">*</span>}
               </label>

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -128,7 +128,9 @@ const styles = {
     }
 
     & .MuiInputBase-input:disabled::placeholder {
-      ${tw`-webkit-text-fill-color[currentColor]` /* to remove -webkit-text-fill-color set by default*/ }
+      ${
+        tw`-webkit-text-fill-color[currentColor]` /* to remove -webkit-text-fill-color set by default*/
+      }
     }
 
     & .MuiFormHelperText-root.Mui-error {
@@ -231,7 +233,12 @@ export const TextField: React.ForwardRefExoticComponent<TextFieldProps> =
         return (
           <div css={[tw`flex flex-col`, twin]}>
             {label && (
-              <label css={[tw`mb-1 text-s font-bold text-shade-medium-default antialiased`, labelTwin]}>
+              <label
+                css={[
+                  tw`mb-1 text-s font-bold text-shade-medium-default antialiased`,
+                  labelTwin,
+                ]}
+              >
                 {label}
                 {required && <span tw="text-negative-medium-default">*</span>}
               </label>

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -115,6 +115,13 @@ const styles = {
       > .Mui-error {
         ${tw`text-negative-medium-default`}
       }
+    & .MuiInputBase-input::placeholder {
+      ${tw`text-shade-light-default opacity-100`}
+    }
+
+    & .MuiInputBase-input:disabled::placeholder {
+      ${tw`-webkit-text-fill-color[currentColor]` /* to remove -webkit-text-fill-color set by default*/ }
+    }
     }
   `,
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -192,7 +192,6 @@ const fontSizes = {
     {
       lineHeight: '1rem',
       letterSpacing: '.03rem',
-      fontFamily: 'YakuHanJP, Inter, Noto Sans JP',
     },
   ],
   s: [
@@ -200,7 +199,6 @@ const fontSizes = {
     {
       lineHeight: '1.25rem',
       letterSpacing: '.03rem',
-      fontFamily: 'YakuHanJP, Inter, Noto Sans JP',
     },
   ],
   r: [
@@ -208,7 +206,6 @@ const fontSizes = {
     {
       lineHeight: '1.5rem',
       letterSpacing: '.03rem',
-      fontFamily: 'YakuHanJP, Inter, Noto Sans JP',
     },
   ],
   xr: [
@@ -216,7 +213,6 @@ const fontSizes = {
     {
       lineHeight: '1.75rem',
       letterSpacing: '.03rem',
-      fontFamily: 'YakuHanJP, Inter, Noto Sans JP',
     },
   ],
   l: [
@@ -224,7 +220,6 @@ const fontSizes = {
     {
       lineHeight: '2rem',
       letterSpacing: '.03rem',
-      fontFamily: 'YakuHanJP, Inter, Noto Sans JP',
     },
   ],
   xl: [
@@ -232,7 +227,6 @@ const fontSizes = {
     {
       lineHeight: '2.5rem',
       letterSpacing: '.03rem',
-      fontFamily: 'YakuHanJP, Inter, Noto Sans JP',
     },
   ],
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -128,7 +128,7 @@ const colors = {
       },
       medium: {
         active: 'var(--primary-border-medium-active)',
-      }
+      },
     },
 
     icon: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -126,6 +126,9 @@ const colors = {
         hover: 'var(--primary-border-dark-hover)',
         disabled: 'var(--primary-border-dark-disabled)',
       },
+      medium: {
+        active: 'var(--primary-border-medium-active)',
+      }
     },
 
     icon: {


### PR DESCRIPTION
### monday

- https://app.asana.com/0/1201386529949743/1201825815636330

### preview

- https://3design-ui-4rye4wxlo-3-shake.vercel.app/?path=/story/atom-textfield--outlined

### 実装内容

- Placeholderの色の調整
- 各所フォント・テキストサイズ類の指定
- paddingの調整
- TextField / Unit : spacingの調整・右寄せ
- Labelのサイズ・margin等の調整

### 相談内容(あれば)
