### PR TITLE
refactor: Chipコンポーネントのデザイン調整

### DIFF
--- a/src/chip/Chip.stories.tsx
+++ b/src/chip/Chip.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Meta, Args } from '@storybook/react/types-6-0'
 
-import tw from 'twin.macro'
+import 'twin.macro'
 import { Text } from '../typography/Typography'
 import { Chip } from './Chip'
 
@@ -32,7 +32,7 @@ export const Base = (args: Args) => (
 
     <div tw="flex flex-col gap-4">
       <div>
-        <Chip label={args.label} color={args.color} twin={[tw`font-bold`]} />
+        <Chip label={args.label} color={args.color} />
       </div>
       <div>
         <Chip label={args.label} color={args.color} onDelete={args.onDelete} />

--- a/src/chip/Chip.stories.tsx
+++ b/src/chip/Chip.stories.tsx
@@ -36,7 +36,16 @@ export const Base = (args: Args) => (
         <Chip label={args.label} color={args.color} />
       </div>
       <div>
-        <Chip label={args.label} color={args.color} onDelete={args.onDelete} />
+        <Chip
+          label={args.label}
+          color={args.color}
+          onDelete={
+            args.onDelete ||
+            (() => {
+              console.log('hello')
+            })
+          }
+        />
       </div>
       <div>
         <Chip
@@ -49,8 +58,7 @@ export const Base = (args: Args) => (
         <Chip
           label={args.label}
           color={args.color}
-          leadingIcon={<MdCheck size={20} tw="ml-0 mr-1" />}
-          isEndIcon
+          trailingIcon={<MdCheck size={20} tw="ml-0 mr-1" />}
         />
       </div>
     </div>

--- a/src/chip/Chip.stories.tsx
+++ b/src/chip/Chip.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { MdCheck } from 'react-icons/md'
 import { Meta, Args } from '@storybook/react/types-6-0'
+import { MdCheck } from 'react-icons/md'
 
 import 'twin.macro'
 import { Text } from '../typography/Typography'

--- a/src/chip/Chip.stories.tsx
+++ b/src/chip/Chip.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Meta } from '@storybook/react/types-6-0'
+import { Meta, Args } from '@storybook/react/types-6-0'
 
-import 'twin.macro'
+import tw from 'twin.macro'
 import { Text } from '../typography/Typography'
 import { Chip } from './Chip'
 
@@ -18,10 +18,13 @@ export default {
   ],
   argTypes: {
     backgroundColor: { control: 'color' },
+    label: { control: 'text', defaultValue: 'ラベル' },
+    color: { control: 'select', options: ['default', 'negative'] },
+    onDelete: { action: 'onDelete' },
   },
 } as Meta
 
-export const Base = () => (
+export const Base = (args: Args) => (
   <div tw="flex flex-col">
     <div tw="border-b mb-4">
       <Text variant="h3">Chip</Text>
@@ -29,10 +32,10 @@ export const Base = () => (
 
     <div tw="flex flex-col gap-4">
       <div>
-        <Chip label="ラベル" />
+        <Chip label={args.label} color={args.color} twin={[tw`font-bold`]} />
       </div>
       <div>
-        <Chip label="ラベル" onDelete={() => console.log('delete')} />
+        <Chip label={args.label} color={args.color} onDelete={args.onDelete} />
       </div>
     </div>
   </div>

--- a/src/chip/Chip.stories.tsx
+++ b/src/chip/Chip.stories.tsx
@@ -20,7 +20,7 @@ export default {
   argTypes: {
     backgroundColor: { control: 'color' },
     label: { control: 'text', defaultValue: 'ラベル' },
-    color: { control: 'select', options: ['default', 'negative'] },
+    color: { control: 'select', options: ['default', 'negative', 'white'] },
     onDelete: { action: 'onDelete' },
   },
 } as Meta
@@ -42,15 +42,15 @@ export const Base = (args: Args) => (
         <Chip
           label={args.label}
           color={args.color}
-          icon={<MdCheck size={20} tw="ml-0 mr-1" />}
+          leadingIcon={<MdCheck size={20} tw="ml-0 mr-1" />}
         />
       </div>
       <div>
         <Chip
           label={args.label}
           color={args.color}
-          icon={<MdCheck size={20} tw="ml-0 mr-1" />}
-          endIcon
+          leadingIcon={<MdCheck size={20} tw="ml-0 mr-1" />}
+          isEndIcon
         />
       </div>
     </div>

--- a/src/chip/Chip.stories.tsx
+++ b/src/chip/Chip.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MdCheck } from 'react-icons/md'
 import { Meta, Args } from '@storybook/react/types-6-0'
 
 import 'twin.macro'
@@ -36,6 +37,21 @@ export const Base = (args: Args) => (
       </div>
       <div>
         <Chip label={args.label} color={args.color} onDelete={args.onDelete} />
+      </div>
+      <div>
+        <Chip
+          label={args.label}
+          color={args.color}
+          icon={<MdCheck size={20} tw="ml-0 mr-1" />}
+        />
+      </div>
+      <div>
+        <Chip
+          label={args.label}
+          color={args.color}
+          icon={<MdCheck size={20} tw="ml-0 mr-1" />}
+          endIcon
+        />
       </div>
     </div>
   </div>

--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -12,28 +12,25 @@ export type ChipProps = Exclude<MuiChipProps, 'color'> & {
   isEndIcon?: boolean
 }
 
-const styles = (color: ChipColorType) => {
-  switch (color) {
-    case 'negative':
-      return css`
-        &.MuiChip-root {
-          ${tw`bg-negative-light-default hover:bg-negative-light-hover`};
-          > .MuiChip-label {
-            ${tw`text-negative-medium-default`};
-          }
-          > .MuiChip-icon {
-            color: ${theme`iconColor.negative.medium.default`};
-          }
-          > .MuiChip-deleteIcon {
-            ${tw`text-negative-medium-default`};
-            &:hover {
-              ${tw`opacity-70`}
-            }
-          }
+const styles = {
+  negative: css`
+    &.MuiChip-root {
+      ${tw`bg-negative-light-default hover:bg-negative-light-hover`};
+      > .MuiChip-label {
+        ${tw`text-negative-medium-default`};
+      }
+      > .MuiChip-icon {
+        color: ${theme`iconColor.negative.medium.default`};
+      }
+      > .MuiChip-deleteIcon {
+        ${tw`text-negative-medium-default`};
+        &:hover {
+          ${tw`opacity-70`}
         }
-      `
-    case 'white':
-      return css`
+      }
+    }
+  `,
+  white: css`
         &.MuiChip-root {
           ${tw`border-solid border-shade-light-default bg-shade-white-default hover:bg-shade-light-hover`};
           > .MuiChip-label {
@@ -48,27 +45,24 @@ const styles = (color: ChipColorType) => {
               color: ${theme`iconColor.primary.dark.hover`} !important;
           }
         }
-      `
-    case 'default':
-    default:
-      return css`
-        &.MuiChip-root {
-          ${tw`border-shade-medium-default bg-shade-light-default hover:bg-shade-light-hover`}
-          > .MuiChip-label {
-            ${tw`text-shade-dark-default`}
-          }
-          > .MuiChip-icon {
-            color: ${theme`iconColor.shade.dark.default`};
-          }
-          > .MuiChip-deleteIcon {
-            ${tw`text-shade-dark-default`}
-            &:hover {
-              color: ${theme`iconColor.primary.dark.hover`} !important;
-            }
-          }
+      `,
+  default: css`
+    &.MuiChip-root {
+      ${tw`border-shade-medium-default bg-shade-light-default hover:bg-shade-light-hover`}
+      > .MuiChip-label {
+        ${tw`text-shade-dark-default`}
+      }
+      > .MuiChip-icon {
+        color: ${theme`iconColor.shade.dark.default`};
+      }
+      > .MuiChip-deleteIcon {
+        ${tw`text-shade-dark-default`}
+        &:hover {
+          color: ${theme`iconColor.primary.dark.hover`} !important;
         }
-      `
-  }
+      }
+    }
+  `,
 }
 
 export const Chip: FC<ChipProps> = ({
@@ -85,7 +79,7 @@ export const Chip: FC<ChipProps> = ({
         css`
           &.MuiChip-root {
             ${tw`border px-3 py-1 h-7`}
-            ${styles(color)}
+            ${styles[`${color}`]}
             ${isEndIcon && tw`flex-row-reverse`}
             ${twin}
             > .MuiChip-label {

--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -1,23 +1,28 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import MuiChip, { ChipProps as MuiChipProps } from '@mui/material/Chip'
 import tw, { css, TwStyle, theme } from 'twin.macro'
 
-type ColorType = 'default' | 'negative'
+type ChipColorType = 'default' | 'negative' | 'white'
 
 export type ChipProps = Exclude<MuiChipProps, 'color'> & {
   twin?: TwStyle[]
-  color?: ColorType
-  endIcon?: React.ReactNode
+  color?: ChipColorType
+  leadingIcon?: MuiChipProps['icon']
+  trailingIcon?: MuiChipProps['deleteIcon']
+  isEndIcon?: boolean
 }
 
-const styles = (color: ColorType) => {
+const styles = (color: ChipColorType) => {
   switch (color) {
     case 'negative':
       return css`
         &.MuiChip-root {
-          ${tw`bg-negative-light-default`};
+          ${tw`bg-negative-light-default hover:bg-negative-light-hover`};
           > .MuiChip-label {
             ${tw`text-negative-medium-default`};
+          }
+          > .MuiChip-icon {
+            color: ${theme`iconColor.negative.medium.default`};
           }
           > .MuiChip-deleteIcon {
             ${tw`text-negative-medium-default`};
@@ -27,13 +32,33 @@ const styles = (color: ColorType) => {
           }
         }
       `
+    case 'white':
+      return css`
+        &.MuiChip-root {
+          ${tw`border-solid border-shade-light-default bg-shade-white-default hover:bg-shade-light-hover`};
+          > .MuiChip-label {
+            ${tw`text-shade-dark-default`};
+          }
+          > .MuiChip-icon {
+            color: ${theme`iconColor.shade.dark.default`};
+          }
+          > .MuiChip-deleteIcon {
+            ${tw`text-shade-dark-default`}
+            &:hover {
+              color: ${theme`iconColor.primary.dark.hover`} !important;
+          }
+        }
+      `
     case 'default':
     default:
       return css`
         &.MuiChip-root {
-          ${tw`border-shade-medium-default bg-shade-light-default`},
+          ${tw`border-shade-medium-default bg-shade-light-default hover:bg-shade-light-hover`}
           > .MuiChip-label {
             ${tw`text-shade-dark-default`}
+          }
+          > .MuiChip-icon {
+            color: ${theme`iconColor.shade.dark.default`};
           }
           > .MuiChip-deleteIcon {
             ${tw`text-shade-dark-default`}
@@ -48,31 +73,31 @@ const styles = (color: ColorType) => {
 
 export const Chip: FC<ChipProps> = ({
   color = 'default',
-  icon,
-  endIcon,
+  leadingIcon,
+  isEndIcon,
   twin,
   ...props
 }) => {
   return (
     <MuiChip
-      icon={icon}
+      icon={leadingIcon}
       css={[
         css`
           &.MuiChip-root {
             ${tw`border px-3 py-1 h-7`}
             ${styles(color)}
-            ${endIcon && tw`flex-row-reverse`}
+            ${isEndIcon && tw`flex-row-reverse`}
             ${twin}
             > .MuiChip-label {
-              ${tw`font-sans text-s pl-0 pr-1`}
-              ${(icon || endIcon) && tw`pr-0!`}
+              ${tw`font-sans text-s px-0`}
+              ${(leadingIcon || isEndIcon) && tw`pr-0!`}
             }
             > .MuiChip-deleteIcon {
               ${tw`ml-0 -mr-1.5`}
             }
             .MuiChip-icon {
-              ${icon && tw`ml-0 mr-1`}
-              ${endIcon && tw`ml-1 mr-0`}
+              ${leadingIcon && tw`ml-0 mr-1`}
+              ${isEndIcon && tw`ml-1 mr-0`}
             }
           }
         `,

--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -4,18 +4,29 @@ import tw, { css, TwStyle, theme } from 'twin.macro'
 
 type ChipColorType = 'default' | 'negative' | 'white'
 
-export type ChipProps = Exclude<MuiChipProps, 'color'> & {
+export type ChipProps = Exclude<
+  MuiChipProps,
+  'color' | 'onDelete' | 'icon' | 'deleteIcon' | 'size'
+> & {
   twin?: TwStyle[]
   color?: ChipColorType
-  leadingIcon?: MuiChipProps['icon']
-  trailingIcon?: MuiChipProps['deleteIcon']
-  isEndIcon?: boolean
-}
+} & (
+    | {
+        leadingIcon: MuiChipProps['icon']
+        trailingIcon?: never
+      }
+    | {
+        leadingIcon?: never
+        trailingIcon?: MuiChipProps['deleteIcon']
+        onDelete?: MuiChipProps['onDelete']
+      }
+  )
 
-const styles = {
+const styles = (clickable: boolean) => ({
   negative: css`
     &.MuiChip-root {
-      ${tw`bg-negative-light-default hover:bg-negative-light-hover`};
+      ${tw`bg-negative-light-default`};
+      ${clickable && tw`hover:bg-negative-light-hover cursor-pointer`};
       > .MuiChip-label {
         ${tw`text-negative-medium-default`};
       }
@@ -25,73 +36,80 @@ const styles = {
       > .MuiChip-deleteIcon {
         ${tw`text-negative-medium-default`};
         &:hover {
-          ${tw`opacity-70`}
+          ${clickable && tw`opacity-70`};
         }
       }
     }
   `,
   white: css`
-        &.MuiChip-root {
-          ${tw`border-solid border-shade-light-default bg-shade-white-default hover:bg-shade-light-hover`};
-          > .MuiChip-label {
-            ${tw`text-shade-dark-default`};
-          }
-          > .MuiChip-icon {
-            color: ${theme`iconColor.shade.dark.default`};
-          }
-          > .MuiChip-deleteIcon {
-            ${tw`text-shade-dark-default`}
-            &:hover {
-              color: ${theme`iconColor.primary.dark.hover`} !important;
-          }
-        }
-      `,
-  default: css`
     &.MuiChip-root {
-      ${tw`border-shade-medium-default bg-shade-light-default hover:bg-shade-light-hover`}
+      ${tw`border-solid border-shade-light-default bg-shade-white-default`};
+      ${clickable && tw`hover:bg-shade-light-hover cursor-pointer`};
       > .MuiChip-label {
-        ${tw`text-shade-dark-default`}
+        ${tw`text-shade-dark-default`};
       }
       > .MuiChip-icon {
         color: ${theme`iconColor.shade.dark.default`};
       }
       > .MuiChip-deleteIcon {
-        ${tw`text-shade-dark-default`}
-        &:hover {
-          color: ${theme`iconColor.primary.dark.hover`} !important;
-        }
+        ${tw`text-shade-dark-default`};
+        ${clickable &&
+        `&:hover {
+              color: ${theme`iconColor.primary.dark.hover`} !important;
+            }`}
       }
     }
   `,
-}
+  default: css`
+    &.MuiChip-root {
+      ${tw`border-shade-medium-default bg-shade-light-default`};
+      ${clickable && tw`hover:bg-shade-light-hover cursor-pointer`};
+      > .MuiChip-label {
+        ${tw`text-shade-dark-default`};
+      }
+      > .MuiChip-icon {
+        color: ${theme`iconColor.shade.dark.default`};
+      }
+      > .MuiChip-deleteIcon {
+        ${tw`text-shade-dark-default`};
+        ${clickable &&
+        `&:hover {
+              color: ${theme`iconColor.primary.dark.hover`} !important;
+            }`}
+      }
+    }
+  `,
+})
 
 export const Chip: FC<ChipProps> = ({
   color = 'default',
   leadingIcon,
-  isEndIcon,
+  trailingIcon,
+  clickable,
+  onDelete,
   twin,
   ...props
 }) => {
   return (
     <MuiChip
-      icon={leadingIcon}
+      icon={!onDelete ? leadingIcon || trailingIcon : undefined}
+      deleteIcon={trailingIcon}
+      onDelete={onDelete}
       css={[
         css`
           &.MuiChip-root {
-            ${tw`border px-3 py-1 h-7`}
-            ${styles[`${color}`]}
-            ${isEndIcon && tw`flex-row-reverse`}
-            ${twin}
-            > .MuiChip-label {
+            ${tw`border px-3 py-1 h-7 inline-flex gap-1`}
+            ${leadingIcon && tw`pl-2`}
+              ${(trailingIcon || onDelete) && tw`pr-2`}
+              ${styles(!!(clickable || onDelete))[`${color}`]}
+              ${!onDelete && trailingIcon ? tw`flex-row-reverse` : ''}
+              ${twin}
+              > .MuiChip-label {
               ${tw`font-sans text-s px-0`}
-              ${(leadingIcon || isEndIcon) && tw`pr-0!`}
             }
-            > .MuiChip-deleteIcon {
-              ${tw`ml-0 -mr-1.5`}
-            }
-            .MuiChip-icon {
-              ${leadingIcon && tw`ml-0 mr-1`}
-              ${isEndIcon && tw`ml-1 mr-0`}
+            > .MuiChip-deleteIcon,
+            > .MuiChip-icon {
+              ${tw`m-0`}
             }
           }
         `,

--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -30,7 +30,7 @@ function styles(color: ColorType) {
     default:
       return css`
         &.MuiChip-root {
-          ${tw`border-shade-medium-default`}
+          ${tw`border-shade-medium-default bg-shade-light-default`},
           > .MuiChip-label {
             ${tw`text-shade-dark-default`}
           }
@@ -51,7 +51,7 @@ export const Chip: VFC<ChipProps> = ({ color = 'default', twin, ...props }) => {
       css={[
         css`
           &.MuiChip-root {
-            ${tw`border px-3 py-1`}
+            ${tw`border px-3 py-1 h-7`}
             ${styles(color)},
             ${twin}
             > .MuiChip-label {

--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from 'react'
+import React, { FC } from 'react'
 import MuiChip, { ChipProps as MuiChipProps } from '@mui/material/Chip'
 import tw, { css, TwStyle, theme } from 'twin.macro'
 
@@ -7,6 +7,7 @@ type ColorType = 'default' | 'negative'
 export type ChipProps = Exclude<MuiChipProps, 'color'> & {
   twin?: TwStyle[]
   color?: ColorType
+  endIcon?: React.ReactNode
 }
 
 const styles = (color: ColorType) => {
@@ -45,20 +46,33 @@ const styles = (color: ColorType) => {
   }
 }
 
-export const Chip: VFC<ChipProps> = ({ color = 'default', twin, ...props }) => {
+export const Chip: FC<ChipProps> = ({
+  color = 'default',
+  icon,
+  endIcon,
+  twin,
+  ...props
+}) => {
   return (
     <MuiChip
+      icon={icon}
       css={[
         css`
           &.MuiChip-root {
             ${tw`border px-3 py-1 h-7`}
-            ${styles(color)},
+            ${styles(color)}
+            ${endIcon && tw`flex-row-reverse`}
             ${twin}
             > .MuiChip-label {
               ${tw`font-sans text-s pl-0 pr-1`}
+              ${(icon || endIcon) && tw`pr-0!`}
             }
             > .MuiChip-deleteIcon {
               ${tw`ml-0 -mr-1.5`}
+            }
+            .MuiChip-icon {
+              ${icon && tw`ml-0 mr-1`}
+              ${endIcon && tw`ml-1 mr-0`}
             }
           }
         `,

--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -2,14 +2,47 @@ import React, { VFC } from 'react'
 import MuiChip, { ChipProps as MuiChipProps } from '@mui/material/Chip'
 import tw, { css, TwStyle, theme } from 'twin.macro'
 
+type ColorType = 'default' | 'negative'
+
 export type ChipProps = Exclude<MuiChipProps, 'color'> & {
   twin?: TwStyle[]
-  color?: 'default' | 'negative'
+  color?: ColorType
 }
 
-const styles: TwStyle = {
-  default: tw`bg-shade-light-default`,
-  negative: tw`bg-negative-light-default`,
+function styles(color: ColorType) {
+  switch (color) {
+    case 'negative':
+      return css`
+        &.MuiChip-root {
+          ${tw`bg-negative-light-default`};
+          > .MuiChip-label {
+            ${tw`text-negative-medium-default`};
+          }
+          > .MuiChip-deleteIcon {
+            ${tw`text-negative-medium-default`};
+            &:hover {
+              ${tw`opacity-70`}
+            }
+          }
+        }
+      `
+    case 'default':
+    default:
+      return css`
+        &.MuiChip-root {
+          ${tw`border-shade-medium-default`}
+          > .MuiChip-label {
+            ${tw`text-shade-dark-default`}
+          }
+          > .MuiChip-deleteIcon {
+            ${tw`text-shade-dark-default`}
+            &:hover {
+              color: ${theme`iconColor.primary.dark.hover`} !important;
+            }
+          }
+        }
+      `
+  }
 }
 
 export const Chip: VFC<ChipProps> = ({ color = 'default', twin, ...props }) => {
@@ -18,19 +51,14 @@ export const Chip: VFC<ChipProps> = ({ color = 'default', twin, ...props }) => {
       css={[
         css`
           &.MuiChip-root {
-            ${tw`border border-shade-medium-default`}
-            ${styles[color]}
+            ${tw`border px-3 py-1`}
+            ${styles(color)},
             ${twin}
-
             > .MuiChip-label {
-              ${tw`font-sans text-s text-shade-dark-default`}
+              ${tw`font-sans text-s pl-0 pr-1`}
             }
-
             > .MuiChip-deleteIcon {
-              ${tw`text-shade-dark-default`}
-              &:hover {
-                color: ${theme`iconColor.primary.dark.hover`} !important;
-              }
+              ${tw`ml-0 -mr-1.5`}
             }
           }
         `,

--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -9,7 +9,7 @@ export type ChipProps = Exclude<MuiChipProps, 'color'> & {
   color?: ColorType
 }
 
-function styles(color: ColorType) {
+const styles = (color: ColorType) => {
   switch (color) {
     case 'negative':
       return css`

--- a/src/styles/tailwind.v2.css
+++ b/src/styles/tailwind.v2.css
@@ -33,6 +33,7 @@
 
   /* shade-background-light */
   --shade-background-light-default: #f4f5fa;
+  --shade-background-light-hover: #e9ecf6;
 
   /* shade-background-white */
   --shade-background-white-default: #fff;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,7 @@ const colors = {
       },
       light: {
         default: 'var(--shade-background-light-default)',
+        hover: 'var(--shade-background-light-hover)',
       },
       white: {
         default: 'var(--shade-background-white-default)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -377,6 +377,7 @@ module.exports = {
       positive: colors.positive.icon,
       notice: colors.notice.icon,
       informative: colors.notice.icon,
+      negative: colors.negative.icon,
     },
     fontSize: {
       xs: fontSizes.s,


### PR DESCRIPTION
### monday

- Chipコンポーネントのデザインと実装に差異がある

### preview

|before|after|
--- | ---
|<img width="208" alt="スクリーンショット 0004-05-20 20 30 15" src="https://user-images.githubusercontent.com/44659317/169521781-a3d60d86-4087-4a33-9fd6-46b6368f61c7.png">|<img width="269" alt="スクリーンショット 0004-05-20 20 46 54" src="https://user-images.githubusercontent.com/44659317/169521924-53ed0a98-3063-446c-96aa-528e6ca2a532.png">|

colorの追加
|negative|white|
--- | ---
|<img width="176" alt="スクリーンショット 0004-05-24 21 18 00" src="https://user-images.githubusercontent.com/44659317/170032805-3d46cf20-913a-4600-8301-2a5633dc1210.png">|<img width="238" alt="スクリーンショット 0004-05-24 21 14 13" src="https://user-images.githubusercontent.com/44659317/170032843-aa5c1b30-8d1c-4c87-9c06-5c809771edf8.png">|

<img width="400" alt="スクリーンショット 0004-05-20 20 44 52" src="https://user-images.githubusercontent.com/44659317/169521864-5dc7ac5a-149c-433b-889f-a9c5f7f74e5c.png">


### 実装内容
- colorでnegativeを選択した場合に背景色しか変更されないので現行デザインと合わせた

### 相談内容(あれば)
- colorTypeの追加があればください〜 🙏 