### PR TITLE
fix: Storyの区分をFigmaと揃える

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,17 +16,8 @@ export const parameters = {
   },
   controls: { expanded: true },
   options: {
-    storySort: (a, b) => {
-      // We want the Welcome story at the top
-      if (b[1].kind === 'Welcome') {
-        return 1
-      }
-
-      // Sort the other stories by ID
-      // https://github.com/storybookjs/storybook/issues/548#issuecomment-530305279
-      return a[1].kind === b[1].kind
-        ? 0
-        : a[1].id.localeCompare(b[1].id, { numeric: true })
+    storySort: {
+      order: ['General', 'Form', 'Data Display', 'Feedback', 'Navigation']
     },
   },
 }

--- a/src/badge/Badge.stories.tsx
+++ b/src/badge/Badge.stories.tsx
@@ -5,7 +5,7 @@ import { MdMail } from 'react-icons/md'
 import { Badge } from './Badge'
 
 export default {
-  title: 'Atom/Badge',
+  title: 'Example / Badge',
   component: Badge,
 } as Meta
 

--- a/src/button/Button.stories.tsx
+++ b/src/button/Button.stories.tsx
@@ -7,7 +7,7 @@ import { Text } from '../typography/Typography'
 import { Button } from './Button'
 
 export default {
-  title: 'Atom/Button',
+  title: 'General / Button',
   component: Button,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/card/Card.stories.tsx
+++ b/src/card/Card.stories.tsx
@@ -5,7 +5,7 @@ import { MdMoreVert } from 'react-icons/md'
 import { Card, CardHeader, CardBody } from './Card'
 
 export default {
-  title: 'Example/Card',
+  title: 'Example / Card',
   component: Card,
   argTypes: {
     backgroundColor: { control: 'color' },

--- a/src/checkbox/Checkbox.stories.tsx
+++ b/src/checkbox/Checkbox.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../button'
 import { Checkbox } from './Checkbox'
 
 export default {
-  title: 'Atom/Checkbox',
+  title: 'Form / Checkbox',
   component: Checkbox,
   decorators: [(Story) => <Story />],
 } as Meta

--- a/src/chip/Chip.stories.tsx
+++ b/src/chip/Chip.stories.tsx
@@ -7,7 +7,7 @@ import { Text } from '../typography/Typography'
 import { Chip } from './Chip'
 
 export default {
-  title: 'Atom/Chip',
+  title: 'Form / Chip',
   component: Chip,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/divider/Divider.stories.tsx
+++ b/src/divider/Divider.stories.tsx
@@ -5,7 +5,7 @@ import 'twin.macro'
 import { Divider } from './Divider'
 
 export default {
-  title: 'Atom/Divider',
+  title: 'Example / Divider',
   component: Divider,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/dropzone/Dropzone.stories.tsx
+++ b/src/dropzone/Dropzone.stories.tsx
@@ -4,7 +4,7 @@ import 'twin.macro'
 import { Dropzone } from './Dropzone'
 
 export default {
-  title: 'Atom/Dropzone',
+  title: 'Form / Dropzone',
   component: Dropzone,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/icon/Icon.stories.tsx
+++ b/src/icon/Icon.stories.tsx
@@ -5,7 +5,7 @@ import { MdNotifications } from 'react-icons/md'
 import { IconButton } from './Icon'
 
 export default {
-  title: 'Example/icon/IconButton',
+  title: 'Example / IconButton',
   component: IconButton,
   argTypes: {
     backgroundColor: { control: 'color' },

--- a/src/layout/Header.stories.tsx
+++ b/src/layout/Header.stories.tsx
@@ -10,7 +10,7 @@ import { Text } from '../typography/Typography'
 import { Header, HeaderLeft, HeaderRight } from './Header'
 
 export default {
-  title: 'Example/Layout/Header',
+  title: 'Example / Layout / Header',
   component: Header,
   argTypes: {
     backgroundColor: { control: 'color' },

--- a/src/layout/Sidebar.stories.tsx
+++ b/src/layout/Sidebar.stories.tsx
@@ -6,7 +6,7 @@ import { MdHome, MdGroup } from 'react-icons/md'
 import { Sidebar, SidebarMenu, SidebarMenuItem } from './Sidebar'
 
 export default {
-  title: 'Example/Layout/Sidebar',
+  title: 'Example / Layout / Sidebar',
   component: Sidebar,
   argTypes: {
     backgroundColor: { control: 'color' },

--- a/src/loader/Loader.stories.tsx
+++ b/src/loader/Loader.stories.tsx
@@ -5,7 +5,7 @@ import { Meta } from '@storybook/react/types-6-0'
 import { Loader } from './Loader'
 
 export default {
-  title: 'Atom/Loader',
+  title: 'Example / Loader',
   component: Loader,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/menu/Menu.stories.tsx
+++ b/src/menu/Menu.stories.tsx
@@ -8,7 +8,7 @@ import { Menu } from './Menu'
 import { MenuItem } from './MenuItem'
 
 export default {
-  title: 'Atom/Menu',
+  title: 'Navigation / Menu',
   component: Menu,
   argTypes: {
     backgroundColor: { control: 'color' },

--- a/src/modal/Modal.stories.tsx
+++ b/src/modal/Modal.stories.tsx
@@ -9,7 +9,7 @@ import { ModalHeader } from './ModalHeader'
 import { Modal } from '.'
 
 export default {
-  title: 'Atom/Modal',
+  title: 'Feedback / Modal',
   component: Modal,
 } as Meta
 

--- a/src/radio/Radio.stories.tsx
+++ b/src/radio/Radio.stories.tsx
@@ -7,7 +7,7 @@ import { Radio } from './Radio'
 import { RadioGroup } from './RadioGroup'
 
 export default {
-  title: 'Atom/Radio',
+  title: 'Form / Radio',
   component: Radio,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/select/Select.stories.tsx
+++ b/src/select/Select.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../button'
 import { Select, SelectOption } from './Select'
 
 export default {
-  title: 'Atom/Select',
+  title: 'Form / Select',
   component: Select,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/skeleton/Skeleton.stories.tsx
+++ b/src/skeleton/Skeleton.stories.tsx
@@ -8,7 +8,7 @@ import { Text, Typography } from '../typography'
 import { Skeleton, SkeletonX } from './Skeleton'
 
 export default {
-  title: 'Atom/Skeleton',
+  title: 'Example / Skeleton',
   component: Skeleton,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/spacer/Spacer.stories.tsx
+++ b/src/spacer/Spacer.stories.tsx
@@ -11,7 +11,7 @@ import tw from 'twin.macro'
 import { Text } from '../typography'
 
 export default {
-  title: 'Example/Spacer',
+  title: 'Example / Spacer',
   component: null,
   argTypes: {
     backgroundColor: { control: 'color' },
@@ -33,7 +33,7 @@ export const Constraints = () => {
       {Object.entries(spacers).map(([k, v]) => (
         <Fragment key={k}>
           <Text variant="caption">{k}</Text>
-          <div css={[v, tw`bg-primary-dark-default`]} />
+          <div tw={[v, tw`bg-primary-dark-default`]} />
         </Fragment>
       ))}
     </Fragment>

--- a/src/stepper/Stepper.stories.tsx
+++ b/src/stepper/Stepper.stories.tsx
@@ -5,7 +5,7 @@ import { Stepper } from './Stepper'
 import 'twin.macro'
 
 export default {
-  title: 'Atom/Stepper',
+  title: 'Navigation / Stepper',
   component: Stepper,
   argTypes: {
     activeStep: { control: { min: 1 } },

--- a/src/switch/Switch.stories.tsx
+++ b/src/switch/Switch.stories.tsx
@@ -7,7 +7,7 @@ import { Switch } from './Switch'
 import { SwitchGroup } from './SwitchGroup'
 
 export default {
-  title: 'Atom/Switch',
+  title: 'Form / Switch',
   component: Switch,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/tab/Tabs.stories.tsx
+++ b/src/tab/Tabs.stories.tsx
@@ -9,7 +9,7 @@ import { TabPanel } from './TabPanel'
 import { Tabs } from './Tabs'
 
 export default {
-  title: 'Atom/Tabs',
+  title: 'Navigation / Tab',
   component: Tabs,
 } as Meta
 

--- a/src/table/Table.stories.tsx
+++ b/src/table/Table.stories.tsx
@@ -11,7 +11,7 @@ import { TableCell } from './TableCell'
 import { TableScroller } from './TableScroller'
 
 export default {
-  title: 'Atom/Table',
+  title: 'Data Display / Table',
   component: Table,
 } as Meta
 

--- a/src/tag/Tag.stories.tsx
+++ b/src/tag/Tag.stories.tsx
@@ -5,7 +5,7 @@ import 'twin.macro'
 import { Tag } from './Tag'
 
 export default {
-  title: 'Atom/Tag',
+  title: 'Example / Tag',
   component: Tag,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/textField/TextField.stories.tsx
+++ b/src/textField/TextField.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from '../button/Button'
 import { TextField } from './TextField'
 
 export default {
-  title: 'Atom/TextField',
+  title: 'Form / TextField',
   component: TextField,
   argTypes: {
     backgroundColor: { control: 'color' },

--- a/src/typography/Typography.stories.tsx
+++ b/src/typography/Typography.stories.tsx
@@ -11,7 +11,7 @@ import tw from 'twin.macro'
 import { Text, Variant, variants, texts } from './Typography'
 
 export default {
-  title: 'Example/Typography',
+  title: 'Example / Typography',
   component: null,
   argTypes: {
     backgroundColor: { control: 'color' },


### PR DESCRIPTION
### チケット

- #636 

### preview

- 

### 実装内容

- Storyの区分をFigmaと揃えた
- 並べ方を変更

<img width="227" alt="image" src="https://user-images.githubusercontent.com/8467289/173034822-2f1a539c-554b-471f-89ee-425231cf2c66.png">


### 相談内容(あれば)
