### PR TITLE
fix: Chipコンポーネントでdefault以外のcolorが選択出来ないのを修正

### DIFF
--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -6,7 +6,7 @@ type ChipColorType = 'default' | 'negative' | 'white'
 
 export type ChipProps = Omit<
   MuiChipProps,
-  'color' | 'icon' | 'deleteIcon' | 'size' 
+  'color' | 'icon' | 'deleteIcon' | 'size'
 > & {
   twin?: TwStyle[]
   color?: ChipColorType

--- a/src/chip/Chip.tsx
+++ b/src/chip/Chip.tsx
@@ -4,9 +4,9 @@ import tw, { css, TwStyle, theme } from 'twin.macro'
 
 type ChipColorType = 'default' | 'negative' | 'white'
 
-export type ChipProps = Exclude<
+export type ChipProps = Omit<
   MuiChipProps,
-  'color' | 'onDelete' | 'icon' | 'deleteIcon' | 'size'
+  'color' | 'icon' | 'deleteIcon' | 'size' 
 > & {
   twin?: TwStyle[]
   color?: ChipColorType


### PR DESCRIPTION
### monday

- Chipコンポーネントをimportした際、`color`の上書きがdefault以外指定できなかった

### preview
|before|after|
--- | ---
|<img width="554" alt="スクリーンショット 0004-06-21 17 30 23" src="https://user-images.githubusercontent.com/44659317/174756642-b8ca7a61-0318-4c18-a2db-3d284e59e8c5.png">|<img width="371" alt="スクリーンショット 0004-06-21 17 31 40" src="https://user-images.githubusercontent.com/44659317/174756714-008bb91a-9e22-4ac8-afa2-487b0caf4ca0.png">|
|<img width="597" alt="スクリーンショット 0004-06-21 17 45 36" src="https://user-images.githubusercontent.com/44659317/174757770-41710d7c-6cac-4e80-9869-5e8ad452089b.png">|<img width="590" alt="スクリーンショット 0004-06-21 17 45 52" src="https://user-images.githubusercontent.com/44659317/174757797-ade48c51-8cfa-41b0-bff9-97fd55b7cdf8.png">|

### 実装内容

- `type`の定義をExcludeではなくOmitに変更
  - https://zenn.dev/woo_noo/articles/31d1366fbfabec2727dc#exclude%3Ct%2C-u%3E-%E3%81%A8%E3%81%AF%3F
### 相談内容(あれば)
