### PR TITLE
refactor: remove console.info

### DIFF
--- a/src/tab/Tabs.tsx
+++ b/src/tab/Tabs.tsx
@@ -26,7 +26,6 @@ export const Tabs: React.VFC<TabsProps> = ({
   children,
   ...rest
 }) => {
-  console.info('value', value)
   return (
     <MuiTabs
       value={value}


### PR DESCRIPTION
### monday

- Tabのコンポーネントを使用している際にconsole.infoが発火され、devtoolsのconsoleにノイズとなってしまっている

### preview

- 

### 実装内容
- Tabsコンポーネント内の`console.info`を削除
### 相談内容(あれば)
