### PR TITLE
feat: Tableコンポーネントでソート機能設定時にStyleを渡るようにする

### DIFF
--- a/src/table/Table.stories.tsx
+++ b/src/table/Table.stories.tsx
@@ -122,6 +122,7 @@ const withSelectColumns: Array<Column<PersonData>> = [
   {
     id: 'id',
     Header: 'id',
+    width: 'auto',
     accessor: 'id',
     Cell: ({ cell: { value, getCellProps } }: CellProps<PersonData>) => (
       <TableCell {...getCellProps()}>{value}</TableCell>
@@ -129,6 +130,7 @@ const withSelectColumns: Array<Column<PersonData>> = [
   },
   {
     Header: '苗字',
+    width: 40,
     accessor: 'lastName',
     Cell: ({ cell: { value, getCellProps } }: CellProps<PersonData>) => (
       <TableCell {...getCellProps()}>{value}</TableCell>
@@ -136,6 +138,7 @@ const withSelectColumns: Array<Column<PersonData>> = [
   },
   {
     Header: '名前',
+    width: 'auto',
     accessor: 'firstName',
     Cell: ({ cell: { value, getCellProps } }: CellProps<PersonData>) => (
       <TableCell {...getCellProps()}>{value}</TableCell>
@@ -143,6 +146,7 @@ const withSelectColumns: Array<Column<PersonData>> = [
   },
   {
     Header: '年齢',
+    width: 'auto',
     accessor: 'age',
     Cell: ({ cell: { value, getCellProps } }: CellProps<PersonData>) => (
       <TableCell {...getCellProps()}>{value}</TableCell>
@@ -150,6 +154,7 @@ const withSelectColumns: Array<Column<PersonData>> = [
   },
   {
     Header: '訪問',
+    width: 'auto',
     accessor: 'visits',
     Cell: ({ cell: { value, getCellProps } }: CellProps<PersonData>) => (
       <TableCell {...getCellProps()}>{value}</TableCell>

--- a/src/table/Table.tsx
+++ b/src/table/Table.tsx
@@ -188,10 +188,14 @@ export const Table = <T extends object>(props: TableProps<T>) => {
                   tw="p-3 text-base text-shade-dark-default text-left whitespace-nowrap bg-shade-white-default z-30"
                   scope="col"
                   {...column.getHeaderProps({
+                    ...(column.getSortByToggleProps
+                      ? column.getSortByToggleProps()
+                      : {}),
                     style: {
                       minWidth: column.minWidth,
                       width: column.width,
                       maxWidth: column.maxWidth,
+                      cursor: column.canSort ? 'pointer' : 'auto',
                     },
                   })}
                   key={j}


### PR DESCRIPTION
### monday

- 

### preview

- 

### 実装内容
-　ソート機能を設定する際に設定したWithが反映されない不具合があった。原因は、`getSortByToggleProps`をStyleに上書きしているためだったので、Styleを最後に展開するようにした。動作確認はStorybookで確認済みのため、おそらくこれが原因だと思われる。

### 相談内容(あれば)
