### PR TITLE
feat: Tab 実装

### DIFF
--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -16,7 +16,7 @@ export const Tab: React.VFC<TabProps> = ({
     <MuiTab
       classes={{
         // eslint-disable-next-line tailwindcss/no-custom-classname
-        root: clsx([`min-w-[${minWidth}] text-primary-medium-default`]),
+        root: clsx([`min-w-[${minWidth}] min-h-[auto] text-primary-medium-default text-r font-bold font-sans pt-2 pb-2.5`]),
         textColorPrimary: clsx(['focus:outline-none']),
         selected: clsx(['text-primary-dark-default focus:outline-none']),
         wrapped: clsx(['focus:outline-none']),

--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -16,7 +16,9 @@ export const Tab: React.VFC<TabProps> = ({
     <MuiTab
       classes={{
         // eslint-disable-next-line tailwindcss/no-custom-classname
-        root: clsx([`min-w-[${minWidth}] min-h-[auto] text-primary-medium-default text-r font-bold font-sans pt-2 pb-2.5`]),
+        root: clsx([
+          `min-w-[${minWidth}] min-h-[auto] pt-2 pb-2.5 font-sans text-r font-bold text-primary-medium-default`,
+        ]),
         textColorPrimary: clsx(['focus:outline-none']),
         selected: clsx(['text-primary-dark-default focus:outline-none']),
         wrapped: clsx(['focus:outline-none']),

--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import MuiTab, { TabProps as MuiTabProps } from '@mui/material/Tab'
+import clsx from 'clsx'
 
 export interface TabProps extends MuiTabProps {
   minWidth?: number
@@ -13,32 +14,13 @@ export const Tab: React.VFC<TabProps> = ({
 }) => {
   return (
     <MuiTab
-      // css={[
-      //   css`
-      //     ${tw`text-primary-medium-default`}
-
-      //     &.MuiTab-root {
-      //       min-width: ${minWidth}px !important;
-      //     }
-
-      //     &.MuiTab-textColorPrimary {
-      //       ${tw`focus:outline-none!`}
-      //     }
-
-      //     &.Mui-selected {
-      //       ${tw`(focus:outline-none text-primary-dark-default)!`}
-
-      //       > .MuiTab-wrapper {
-      //         ${tw`text-primary-dark-default!`}
-      //       }
-      //     }
-
-      //     > .MuiTab-wrapper {
-      //       ${tw`text-shade-medium-default!`}
-      //     }
-      //   `,
-      //   twin,
-      // ]}
+      classes={{
+        // eslint-disable-next-line tailwindcss/no-custom-classname
+        root: clsx([`min-w-[${minWidth}] text-primary-medium-default`]),
+        textColorPrimary: clsx(['focus:outline-none']),
+        selected: clsx(['text-primary-dark-default focus:outline-none']),
+        wrapped: clsx(['focus:outline-none']),
+      }}
       disabled={disabled}
       tabIndex={tabIndex}
       {...rest}

--- a/src/tab/TabList.tsx
+++ b/src/tab/TabList.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import MuiTabList, { TabListProps as MuiTabListProps } from '@mui/lab/TabList'
+import { Box } from '@mui/material'
+import clsx from 'clsx'
 
 export interface TabListProps extends MuiTabListProps {
   noBorder?: boolean
@@ -7,14 +9,43 @@ export interface TabListProps extends MuiTabListProps {
   color?: 'primary' | 'secondary' | 'shade'
 }
 
-// const colorStyle = {
-//   primary: tw`bg-primary-dark-default`,
-//   secondary: tw`bg-secondary-dark-default`,
-//   shade: tw`bg-shade-medium-default`,
-// }
+const colorStyle = {
+  primary: clsx`bg-primary-dark-default`,
+  secondary: clsx`bg-secondary-dark-default`,
+  shade: clsx`bg-shade-medium-default`,
+}
 
-export const TabList: React.VFC<TabListProps> = ({
-  noBorder = false,
+export const TabList: React.FC<TabListProps> = (props) => {
+  return props.noBorder ? (
+    <_TabList {...props}>{props.children}</_TabList>
+  ) : (
+    <BorderedTabList {...props} />
+  )
+}
+
+const BorderedTabList: React.FC<TabListProps> = (props) => (
+  <Box className="w-full">
+    {!props.noBorder && props.reverse && (
+      <div
+        className={clsx([
+          'absolute box-border h-[1px] w-full bg-shade-light-default',
+        ])}
+      />
+    )}
+
+    <_TabList {...props}>{props.children}</_TabList>
+
+    {!props.noBorder && !props.reverse && (
+      <div
+        className={clsx([
+          'absolute box-border h-[1px] w-full bg-shade-light-default',
+        ])}
+      />
+    )}
+  </Box>
+)
+
+const _TabList: React.FC<TabListProps> = ({
   reverse = false,
   color = 'secondary',
   onChange,
@@ -25,21 +56,9 @@ export const TabList: React.VFC<TabListProps> = ({
     <MuiTabList
       onChange={onChange}
       aria-label="lab API tabs example"
-      // css={[
-      //   css`
-      //     &.MuiTabs-root {
-      //       ${reverse
-      //         ? tw`(border-shade-light-default border-t-2)!`
-      //         : tw`(border-shade-light-default border-b-2)!`}
-      //     }
-      //     & .MuiTabs-indicator {
-      //       ${colorStyle[color]}
-      //       ${reverse && tw`top-0`}
-      //     }
-      //   `,
-      //   noBorder && tw`border-none!`,
-      //   twin,
-      // ]}
+      classes={{
+        indicator: clsx([colorStyle[color], reverse && 'top-0']),
+      }}
       {...rest}
     >
       {children}

--- a/src/tab/TabPanel.tsx
+++ b/src/tab/TabPanel.tsx
@@ -2,20 +2,16 @@ import React from 'react'
 import MuiTabPanel, {
   TabPanelProps as MuiTabPanelProps,
 } from '@mui/lab/TabPanel'
+import clsx from 'clsx'
 
 export type TabPanelProps = MuiTabPanelProps
 
-export const TabPanel: React.VFC<TabPanelProps> = ({ value, children }) => {
+export const TabPanel: React.FC<TabPanelProps> = ({ value, children }) => {
   return (
     <MuiTabPanel
-      // css={[
-      //   css`
-      //     &.MuiTabPanel-root {
-      //       ${tw`px-0`}
-      //     }
-      //   `,
-      //   twin,
-      // ]}
+      classes={{
+        root: clsx(['px-0']),
+      }}
       value={value}
     >
       {children}

--- a/src/tab/Tabs.stories.tsx
+++ b/src/tab/Tabs.stories.tsx
@@ -65,27 +65,7 @@ const Template: Story = () => {
 
       <div className="mt-8 flex flex-col">
         <TabContext value={value}>
-          <Tabs value={value} onChange={handleChange} color="shade">
-            <Tab value="1" label="Item One" minWidth={0} />
-            <Tab value="2" label="Item Two" />
-            <Tab value="3" label="Item Three" />
-          </Tabs>
-
-          <TabPanel value="1">
-            <h1>shade 1</h1>
-          </TabPanel>
-          <TabPanel value="2">
-            <h1>shade 2</h1>
-          </TabPanel>
-          <TabPanel value="3">
-            <h1>shade 3</h1>
-          </TabPanel>
-        </TabContext>
-      </div>
-
-      <div className="mt-8 flex flex-col">
-        <TabContext value={value}>
-          <Tabs value={value} onChange={handleChange} color="shade" noBorder>
+          <Tabs value={value} onChange={handleChange} noBorder>
             <Tab value="1" label="Item One" minWidth={0} />
             <Tab value="2" label="Item Two" />
             <Tab value="3" label="Item Three" />

--- a/src/tab/Tabs.tsx
+++ b/src/tab/Tabs.tsx
@@ -6,13 +6,12 @@ import clsx from 'clsx'
 export interface TabsProps extends MuiTabsProps {
   noBorder?: boolean
   reverse?: boolean
-  color?: 'primary' | 'secondary' | 'shade'
+  color?: 'primary' | 'secondary'
 }
 
 const colorStyle = {
   primary: clsx`bg-primary-dark-default`,
   secondary: clsx`bg-secondary-dark-default`,
-  shade: clsx`bg-shade-medium-default`,
 }
 
 export const Tabs: React.FC<TabsProps> = (props) => {

--- a/src/tab/Tabs.tsx
+++ b/src/tab/Tabs.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+import { Box } from '@mui/material'
 import MuiTabs, { TabsProps as MuiTabsProps } from '@mui/material/Tabs'
+import clsx from 'clsx'
 
 export interface TabsProps extends MuiTabsProps {
   noBorder?: boolean
@@ -7,14 +9,43 @@ export interface TabsProps extends MuiTabsProps {
   color?: 'primary' | 'secondary' | 'shade'
 }
 
-// const colorStyle = {
-//   primary: tw`bg-primary-dark-default`,
-//   secondary: tw`bg-secondary-dark-default`,
-//   shade: tw`bg-shade-medium-default`,
-// }
+const colorStyle = {
+  primary: clsx`bg-primary-dark-default`,
+  secondary: clsx`bg-secondary-dark-default`,
+  shade: clsx`bg-shade-medium-default`,
+}
 
-export const Tabs: React.FC<TabsProps> = ({
-  noBorder = false,
+export const Tabs: React.FC<TabsProps> = (props) => {
+  return props.noBorder ? (
+    <_Tabs {...props}>{props.children}</_Tabs>
+  ) : (
+    <BorderedTabs {...props} />
+  )
+}
+
+const BorderedTabs: React.FC<TabsProps> = (props) => (
+  <Box className="w-full">
+    {!props.noBorder && props.reverse && (
+      <div
+        className={clsx([
+          'absolute box-border h-[1px] w-full bg-shade-light-default',
+        ])}
+      />
+    )}
+
+    <_Tabs {...props}>{props.children}</_Tabs>
+
+    {!props.noBorder && !props.reverse && (
+      <div
+        className={clsx([
+          'absolute box-border h-[1px] w-full bg-shade-light-default',
+        ])}
+      />
+    )}
+  </Box>
+)
+
+const _Tabs: React.FC<TabsProps> = ({
   reverse = false,
   color = 'secondary',
   value,
@@ -26,21 +57,9 @@ export const Tabs: React.FC<TabsProps> = ({
     <MuiTabs
       value={value}
       onChange={onChange}
-      // css={[
-      //   css`
-      //     &.MuiTabs-root {
-      //       ${reverse
-      //         ? tw`(border-shade-light-default border-t-2)!`
-      //         : tw`(border-shade-light-default border-b-2)!`}
-      //     }
-      //     & .MuiTabs-indicator {
-      //       ${colorStyle[color]}
-      //       ${reverse && tw`top-0`}
-      //     }
-      //   `,
-      //   noBorder && tw`border-none!`,
-      //   twin,
-      // ]}
+      classes={{
+        indicator: clsx([colorStyle[color], reverse && 'top-0']),
+      }}
       {...rest}
     >
       {children}

--- a/src/tab/Tabs.tsx
+++ b/src/tab/Tabs.tsx
@@ -58,6 +58,7 @@ const _Tabs: React.FC<TabsProps> = ({
       value={value}
       onChange={onChange}
       classes={{
+        root: clsx(['min-h-[auto]']),
         indicator: clsx([colorStyle[color], reverse && 'top-0']),
       }}
       {...rest}

--- a/src/tab/Tabs.tsx
+++ b/src/tab/Tabs.tsx
@@ -27,7 +27,7 @@ const BorderedTabs: React.FC<TabsProps> = (props) => (
     {!props.noBorder && props.reverse && (
       <div
         className={clsx([
-          'absolute box-border h-[1px] w-full bg-shade-light-default',
+          'absolute box-border h-0 w-full border-b-[1px] border-solid border-shade-light-default',
         ])}
       />
     )}
@@ -37,7 +37,7 @@ const BorderedTabs: React.FC<TabsProps> = (props) => (
     {!props.noBorder && !props.reverse && (
       <div
         className={clsx([
-          'absolute box-border h-[1px] w-full bg-shade-light-default',
+          'absolute box-border h-0 w-full border-b-[1px] border-solid border-shade-light-default',
         ])}
       />
     )}


### PR DESCRIPTION
https://github.com/3-shake/3design-ui/issues/687

### 元のデザイン
https://3design-ui.vercel.app/?path=/story/navigation-tab--default-tab

### 実装後のデザイン
https://3design-ui-v3-git-feat-tab-3-shake.vercel.app/?path=/story/navigation-tab--default-tab


### 困っていること
borderがおかしかったので、修正しました。
変更方法としてはborder ではなく、width/height のデザインに変更したのですが、
そうなるとborder-xxxx ではなく、bg-xxxxx になるので、borderのカラーが変わってしまうのですが、
どうしましょう？
@Qs-F 
