### PR TITLE
fix: content turborepo/vite-app 対応 \w tailwindcss.config.base.js

### DIFF
--- a/.changeset/chilled-trees-enjoy.md
+++ b/.changeset/chilled-trees-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@3design/3design-ui": patch
+---
+
+fix: content turborepo/vite-app 対応 \w tailwindcss.config.base.js

--- a/packages/3design-ui/tailwind.config.base.js
+++ b/packages/3design-ui/tailwind.config.base.js
@@ -348,6 +348,11 @@ const fontSizes = {
 };
 
 module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+    '../../node_modules/@3design/3design-ui/dist/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@3design/3design-ui/dist/**/*.{js,ts,jsx,tsx}',
+  ],
   plugins: [
     plugin(({ matchUtilities, theme, corePlugins }) => {
       matchUtilities(


### PR DESCRIPTION
## 実装内容
以下tailwindcss デフォルトcontent 対応
* 3design-ui 
* src/** 